### PR TITLE
Avoid rebuilding the function image when the source code is updated i…

### DIFF
--- a/.devops/code-review-pipelines.yml
+++ b/.devops/code-review-pipelines.yml
@@ -88,6 +88,7 @@ stages:
             yarn start
           displayName: 'Start test resources'
         - script: |
+            yarn build
             cd __integrations__
             yarn install --frozen-lockfile
             sleep 30s

--- a/.devops/code-review-pipelines.yml
+++ b/.devops/code-review-pipelines.yml
@@ -81,6 +81,7 @@ stages:
         steps:
         - template: templates/node-job-setup/template.yaml@pagopaCommons
         - script: |
+            yarn build
             cd __integrations__
             sed -i 's/FF_TYPE=.*/FF_TYPE=none/g' environments/env.base
             cp environments/env.base environments/.env
@@ -99,6 +100,7 @@ stages:
         steps:
         - template: templates/node-job-setup/template.yaml@pagopaCommons
         - script: |
+            yarn build
             cd __integrations__
             sed -i 's/FF_TYPE=.*/FF_TYPE=prod/g' environments/env.base
             cp environments/env.base environments/.env
@@ -106,6 +108,7 @@ stages:
             yarn start
           displayName: 'Start test resources'
         - script: |
+            yarn build
             cd __integrations__
             yarn install --frozen-lockfile
             sleep 30s

--- a/README.md
+++ b/README.md
@@ -111,3 +111,19 @@ Then you can stop all the containers running
 ```
 yarn stop
 ```
+
+### Debugging
+
+When the container `fn-service-messages` is up and running and you want to update the source code to make a fix
+or to add some logs during debugging, you don't need to rebuild the entire image, just run
+
+```bash
+yarn build
+```
+
+In the root of the project in order to update the source code inside the `dist/` folder and then you only need to restart
+the container to see the changes by running
+
+```bash
+docker compose --env-file environments/.env restart function
+```

--- a/__integrations__/docker-compose.yml
+++ b/__integrations__/docker-compose.yml
@@ -59,7 +59,7 @@ services:
       test: ["CMD", "curl", "-f", "http://function:7071/api/live"]
       interval: 12s
       timeout: 15s
-      retries: 5
+      retries: 10
     build:
       context: ..
       dockerfile: ./docker/functions/Dockerfile

--- a/__integrations__/docker-compose.yml
+++ b/__integrations__/docker-compose.yml
@@ -58,11 +58,13 @@ services:
     healthcheck:
       test: ["CMD", "curl", "-f", "http://function:7071/api/live"]
       interval: 12s
-      timeout: 10s
+      timeout: 15s
       retries: 5
     build:
       context: ..
       dockerfile: ./docker/functions/Dockerfile
+    volumes:
+      - "../:/usr/src/app"
     ports:
       - ${FUNCTION_PORT}:7071
     links:

--- a/__integrations__/docker-compose.yml
+++ b/__integrations__/docker-compose.yml
@@ -77,8 +77,7 @@ services:
 
   testagent:
     container_name: fn-service-messages-testagent
-    # FIX: use node 18 instead
-    image: node:16-alpine
+    image: node:18-alpine
     working_dir: /usr/src/app
     command: tail -f /dev/null # to keep it   up&running
     env_file:

--- a/docker/functions/Dockerfile
+++ b/docker/functions/Dockerfile
@@ -1,10 +1,5 @@
 FROM functions-node-18
 
-COPY . /usr/src/app
-
 RUN func extensions install
-
-RUN yarn install --frozen-lockfile
-RUN yarn build
 
 CMD ["func", "start", "--javascript"]


### PR DESCRIPTION
…n integration test

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->

* [Avoid rebuilding the function image when the source code is updated i…](https://github.com/pagopa/io-functions-service-messages/commit/4083c8fce448014069c620ea20571a8b4044f388);

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

During the process of debugging using the integration test  we need to rebuild the entire function image every time we make a change to the source code which takes (in my local machine) about 350 seconds.
This can be quite frustrating.
The goal of this PR is to skip the step of building the function image reducing the time needed to debug while making integration tests.
After those changes we only need to restart the container which takes more or less 30 seconds in my machine

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
integration tests

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
