### PR TITLE
[IOCOM-1326] Changed base path to be aligned with other external apis

### DIFF
--- a/openapi/index.yaml
+++ b/openapi/index.yaml
@@ -1,7 +1,7 @@
 swagger: '2.0'
 info:
   version: 1.10.5
-  title: IO API for service Messages
+  title: IO internal API for messages sending functions
   contact:
     name: PagoPA
     url: https://forum.italia.it/c/progetto-io
@@ -10,7 +10,7 @@ info:
   description: |
     # Warning Experimental API These apis are experimental and for internal use.
 host: api.io.pagopa.it
-basePath: /service-messages/api/v1
+basePath: /api/v1/messages-sending/internal
 schemes:
   - https
 security:

--- a/openapi/index_external.yaml
+++ b/openapi/index_external.yaml
@@ -1,7 +1,7 @@
 swagger: '2.0'
 info:
   version: 1.10.5
-  title: IO API for service Messages
+  title: IO API for messages sending functions
   contact:
     name: PagoPA
     url: https://forum.italia.it/c/progetto-io
@@ -10,7 +10,7 @@ info:
   description: |
     External manage apis to manage message related entities.
 host: api.io.pagopa.it
-basePath: /service-messages/api/v1
+basePath: /api/v1/messages-sending
 schemes:
   - https
 security:

--- a/openapi/index_external.yaml.template
+++ b/openapi/index_external.yaml.template
@@ -1,7 +1,7 @@
 swagger: '2.0'
 info:
   version: 1.4.0
-  title: IO API for service Messages
+  title: IO API for messages sending functions
   contact:
     name: PagoPA
     url: https://forum.italia.it/c/progetto-io
@@ -10,7 +10,7 @@ info:
   description: >
     External manage apis to manage message related entities.
 host: api.io.pagopa.it
-basePath: /service-messages/api/v1
+basePath: /api/v1/messages-sending
 schemes:
   - https
 security:

--- a/openapi/index_internal.yaml.template
+++ b/openapi/index_internal.yaml.template
@@ -1,7 +1,7 @@
 swagger: '2.0'
 info:
   version: 1.4.0
-  title: IO API for service Messages
+  title: IO internal API for messages sending functions
   contact:
     name: PagoPA
     url: https://forum.italia.it/c/progetto-io
@@ -11,7 +11,7 @@ info:
     # Warning Experimental API
     These apis are experimental and for internal use.
 host: api.io.pagopa.it
-basePath: /service-messages/api/v1
+basePath: /api/v1/messages-sending/internal
 schemes:
   - https
 security:


### PR DESCRIPTION
#### List of Changes
Moved external base path to `/api/v1/messages-sending`.
Moved internal base path to `/api/v1/messages-sending/internal`.
Used `messages-sending` as product name to be compliant with azure functions name and not with repo name.

#### Motivation and Context
We need to align openapi specs to the existing ones.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
