### PR TITLE
[IOCOM-1364] feat: track a not sampled event for rc configuration update

### DIFF
--- a/UpdateRCConfiguration/__tests__/updateRCConfiguration.test.ts
+++ b/UpdateRCConfiguration/__tests__/updateRCConfiguration.test.ts
@@ -20,11 +20,17 @@ import {
 import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 import { redisClientMock } from "../../__mocks__/redis.mock";
 import { RC_CONFIGURATION_REDIS_PREFIX } from "../../GetRCConfiguration/handler";
+import { TelemetryClient } from "applicationinsights";
 
 const setWithExpirationTaskMock = jest.fn();
 jest
   .spyOn(redis_storage, "setWithExpirationTask")
   .mockImplementation(setWithExpirationTaskMock);
+
+const trackEventMock = jest.fn();
+const telemetryClientMock = ({
+  trackEvent: trackEventMock
+} as unknown) as TelemetryClient;
 
 describe("isUserAllowedToUpdateConfiguration", () => {
   test("should return a left if the userId is not equal to the userId of the configuration", async () => {
@@ -99,7 +105,8 @@ describe("handleUpsert", () => {
     const r = await handleUpsert({
       rccModel: rccModelMock,
       config: envConfig,
-      redisClientFactory: redisClientMock
+      redisClientFactory: redisClientMock,
+      telemetryClient: telemetryClientMock
     })(aRemoteContentConfiguration)();
     expect(E.isLeft(r)).toBe(true);
     expect(setWithExpirationTaskMock).not.toHaveBeenCalled();
@@ -118,7 +125,8 @@ describe("handleUpsert", () => {
     const r = await handleUpsert({
       rccModel: rccModelMock,
       config: envConfig,
-      redisClientFactory: redisClientMock
+      redisClientFactory: redisClientMock,
+      telemetryClient: telemetryClientMock
     })(aRemoteContentConfiguration)();
     expect(E.isRight(r)).toBe(true);
     expect(setWithExpirationTaskMock).toHaveBeenCalledWith(
@@ -141,7 +149,8 @@ describe("handleUpsert", () => {
     const r = await handleUpsert({
       rccModel: rccModelMock,
       config: envConfig,
-      redisClientFactory: redisClientMock
+      redisClientFactory: redisClientMock,
+      telemetryClient: telemetryClientMock
     })(aRemoteContentConfiguration)();
     expect(E.isRight(r)).toBe(true);
     expect(setWithExpirationTaskMock).toHaveBeenCalledWith(

--- a/UpdateRCConfiguration/index.ts
+++ b/UpdateRCConfiguration/index.ts
@@ -13,6 +13,7 @@ import { remoteContentCosmosDbInstance } from "../utils/cosmosdb";
 import { getConfigOrThrow } from "../utils/config";
 import { RedisClientFactory } from "../utils/redis";
 import { getUpdateRCConfigurationExpressHandler } from "./handler";
+import { initTelemetryClient } from "../utils/appinsights";
 
 const rccModel = new RCConfigurationModel(
   remoteContentCosmosDbInstance.container(RC_CONFIGURATION_COLLECTION_NAME)
@@ -26,13 +27,16 @@ const redisClientFactory = new RedisClientFactory(config);
 const app = express();
 secureExpressApp(app);
 
+const telemetryClient = initTelemetryClient();
+
 // Add express route
 app.put(
   "/api/v1/remote-contents/configurations/:configurationId",
   getUpdateRCConfigurationExpressHandler({
     config,
     rccModel,
-    redisClientFactory
+    redisClientFactory,
+    telemetryClient
   })
 );
 


### PR DESCRIPTION
#### List of Changes
Added a `remote.content.configuration.updated` event tracking for any rc configuration update.

#### Motivation and Context
We need to track if a user updates his configuration to simplify troubleshooting.

#### How Has This Been Tested?
unit tests

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

