### PR TITLE
[IOCOM-1327] Check manage  user group and subscription for RCConfiguration APIs

### DIFF
--- a/CreateRCConfiguration/__tests__/handler.test.ts
+++ b/CreateRCConfiguration/__tests__/handler.test.ts
@@ -2,11 +2,15 @@ import * as E from "fp-ts/lib/Either";
 import * as TE from "fp-ts/lib/TaskEither";
 
 import {
+  aManageSubscriptionId,
   aPublicRemoteContentConfiguration,
   aRemoteContentConfiguration,
+  aSubscriptionId,
   aUserId,
   createNewConfigurationMock,
-  rccModelMock
+  rccModelMock,
+  someUserGroups,
+  someUserGroupsWithTheAllowedOne
 } from "../../__mocks__/remote-content";
 import { ulidGeneratorAsUlid } from "@pagopa/io-functions-commons/dist/src/utils/strings";
 import { createRCConfigurationHandler } from "../handler";
@@ -39,12 +43,14 @@ describe("createRCConfigurationHandler", () => {
       newRCConfiguration: {
         ...aPublicRemoteContentConfiguration
       },
+      subscriptionId: aManageSubscriptionId,
+      userGroups: someUserGroupsWithTheAllowedOne,
       userId: aUserId
     });
 
     expect(r.kind).toBe("IResponseErrorInternal");
     expect(r.detail).toBe(
-      "Internal server error: Error creating the new configuration: undefined"
+      "Internal server error: Something went wrong trying to create the configuration: {}"
     );
   });
 
@@ -57,6 +63,8 @@ describe("createRCConfigurationHandler", () => {
       generateConfigurationId: ulidGeneratorAsUlid
     })({
       newRCConfiguration: aPublicRemoteContentConfiguration,
+      subscriptionId: aManageSubscriptionId,
+      userGroups: someUserGroupsWithTheAllowedOne,
       userId: aUserId
     });
 
@@ -65,5 +73,41 @@ describe("createRCConfigurationHandler", () => {
       expect(r.payload).toMatchObject({
         ...aPublicRemoteContentConfiguration
       });
+  });
+
+  test("should return 403 if group is not allowed", async () => {
+    createNewConfigurationMock.mockReturnValueOnce(
+      TE.right(aRemoteContentConfiguration)
+    );
+    const r = await createRCConfigurationHandler({
+      rccModel: rccModelMock,
+      generateConfigurationId: ulidGeneratorAsUlid
+    })({
+      newRCConfiguration: aPublicRemoteContentConfiguration,
+      subscriptionId: aManageSubscriptionId,
+      userGroups: someUserGroups,
+      userId: aUserId
+    });
+
+    expect(r.kind).toBe("IResponseErrorForbiddenNotAuthorized");
+    expect(createNewConfigurationMock).not.toHaveBeenCalled();
+  });
+
+  test("should return 403 if subscription is not manage", async () => {
+    createNewConfigurationMock.mockReturnValueOnce(
+      TE.right(aRemoteContentConfiguration)
+    );
+    const r = await createRCConfigurationHandler({
+      rccModel: rccModelMock,
+      generateConfigurationId: ulidGeneratorAsUlid
+    })({
+      newRCConfiguration: aPublicRemoteContentConfiguration,
+      subscriptionId: aSubscriptionId,
+      userGroups: someUserGroupsWithTheAllowedOne,
+      userId: aUserId
+    });
+
+    expect(r.kind).toBe("IResponseErrorForbiddenNotAuthorized");
+    expect(createNewConfigurationMock).not.toHaveBeenCalled();
   });
 });

--- a/CreateRCConfiguration/__tests__/handler.test.ts
+++ b/CreateRCConfiguration/__tests__/handler.test.ts
@@ -34,6 +34,10 @@ describe("makeNewRCConfigurationWithConfigurationId", () => {
 });
 
 describe("createRCConfigurationHandler", () => {
+  beforeEach(async () => {
+    jest.clearAllMocks();
+  });
+
   test("should return 500 if the model return an error", async () => {
     createNewConfigurationMock.mockReturnValueOnce(TE.left({}));
     const r = await createRCConfigurationHandler({
@@ -76,9 +80,7 @@ describe("createRCConfigurationHandler", () => {
   });
 
   test("should return 403 if group is not allowed", async () => {
-    createNewConfigurationMock.mockReturnValueOnce(
-      TE.right(aRemoteContentConfiguration)
-    );
+    createNewConfigurationMock.mockReturnValueOnce(TE.left({}));
     const r = await createRCConfigurationHandler({
       rccModel: rccModelMock,
       generateConfigurationId: ulidGeneratorAsUlid
@@ -94,9 +96,7 @@ describe("createRCConfigurationHandler", () => {
   });
 
   test("should return 403 if subscription is not manage", async () => {
-    createNewConfigurationMock.mockReturnValueOnce(
-      TE.right(aRemoteContentConfiguration)
-    );
+    createNewConfigurationMock.mockReturnValueOnce(TE.left({}));
     const r = await createRCConfigurationHandler({
       rccModel: rccModelMock,
       generateConfigurationId: ulidGeneratorAsUlid

--- a/ListRCConfiguration/__tests__/handler.test.ts
+++ b/ListRCConfiguration/__tests__/handler.test.ts
@@ -72,7 +72,7 @@ describe("listRCConfigurationHandler", () => {
     });
     expect(r.kind).toBe("IResponseErrorInternal");
     expect(r.detail).toContain(
-      "Internal server error: Something went wrong trying to retrieve the configurations"
+      "Internal server error: Something went wrong trying to retrieve the user's configurations"
     );
   });
 

--- a/ListRCConfiguration/__tests__/handler.test.ts
+++ b/ListRCConfiguration/__tests__/handler.test.ts
@@ -53,7 +53,6 @@ describe("listRCConfigurationHandler", () => {
       userGroups: someUserGroupsWithTheAllowedOne,
       userId: aRemoteContentConfiguration.userId
     });
-    console.log(r.detail);
     expect(r.kind).toBe("IResponseSuccessJson");
     if (r.kind === "IResponseSuccessJson") {
       expect(r.value.rcConfigList).toHaveLength(0);

--- a/ListRCConfiguration/__tests__/handler.test.ts
+++ b/ListRCConfiguration/__tests__/handler.test.ts
@@ -10,30 +10,27 @@ import {
   rccModelMock,
   userRCCModelMock,
   aManageSubscriptionId,
-  aSubscriptionId
+  aSubscriptionId,
+  someUserGroupsWithTheAllowedOne,
+  someUserGroups
 } from "../../__mocks__/remote-content";
 
-import {
-  listRCConfigurationHandler
-} from "../handler";
+import { listRCConfigurationHandler } from "../handler";
 import { RetrievedUserRCConfiguration } from "@pagopa/io-functions-commons/dist/src/models/user_rc_configuration";
 import { RetrievedRCConfiguration } from "@pagopa/io-functions-commons/dist/src/models/rc_configuration";
 
 describe("listRCConfigurationHandler", () => {
   test("should return an IResponseSuccessJson if the model return a valid configuration and the userId match", async () => {
-    findAllByUserId.mockReturnValueOnce(
-      TE.right(aUserRCCList)
-    );
-    findAllByConfigurationId.mockReturnValueOnce(
-      TE.right(allConfigurations)
-    );
+    findAllByUserId.mockReturnValueOnce(TE.right(aUserRCCList));
+    findAllByConfigurationId.mockReturnValueOnce(TE.right(allConfigurations));
 
     const r = await listRCConfigurationHandler({
       rcConfigurationModel: rccModelMock,
       userRCConfigurationModel: userRCCModelMock
     })({
-      userId: aRemoteContentConfiguration.userId,
-      subscriptionId: aManageSubscriptionId
+      subscriptionId: aManageSubscriptionId,
+      userGroups: someUserGroupsWithTheAllowedOne,
+      userId: aRemoteContentConfiguration.userId
     });
     expect(r.kind).toBe("IResponseSuccessJson");
     if (r.kind === "IResponseSuccessJson") {
@@ -52,8 +49,9 @@ describe("listRCConfigurationHandler", () => {
       rcConfigurationModel: rccModelMock,
       userRCConfigurationModel: userRCCModelMock
     })({
-      userId: aRemoteContentConfiguration.userId,
-      subscriptionId: aManageSubscriptionId
+      subscriptionId: aManageSubscriptionId,
+      userGroups: someUserGroupsWithTheAllowedOne,
+      userId: aRemoteContentConfiguration.userId
     });
     console.log(r.detail);
     expect(r.kind).toBe("IResponseSuccessJson");
@@ -68,8 +66,9 @@ describe("listRCConfigurationHandler", () => {
       rcConfigurationModel: rccModelMock,
       userRCConfigurationModel: userRCCModelMock
     })({
-      userId: aRemoteContentConfiguration.userId,
-      subscriptionId: aManageSubscriptionId
+      subscriptionId: aManageSubscriptionId,
+      userGroups: someUserGroupsWithTheAllowedOne,
+      userId: aRemoteContentConfiguration.userId
     });
     expect(r.kind).toBe("IResponseErrorInternal");
     expect(r.detail).toContain(
@@ -78,13 +77,37 @@ describe("listRCConfigurationHandler", () => {
   });
 
   test("should return an IResponseErrorForbiddenNotAuthorized if not called from a manage subscription", async () => {
-    findAllByUserId.mockReturnValueOnce(TE.left(O.none));
+    findAllByUserId.mockReturnValueOnce(
+      TE.right([] as ReadonlyArray<RetrievedUserRCConfiguration>)
+    );
+    findAllByConfigurationId.mockReturnValueOnce(
+      TE.right([] as ReadonlyArray<RetrievedRCConfiguration>)
+    );
     const r = await listRCConfigurationHandler({
       rcConfigurationModel: rccModelMock,
       userRCConfigurationModel: userRCCModelMock
     })({
-      userId: aRemoteContentConfiguration.userId,
-      subscriptionId: aSubscriptionId
+      subscriptionId: aSubscriptionId,
+      userGroups: someUserGroupsWithTheAllowedOne,
+      userId: aRemoteContentConfiguration.userId
+    });
+    expect(r.kind).toBe("IResponseErrorForbiddenNotAuthorized");
+  });
+
+  test("should return an IResponseErrorForbiddenNotAuthorized if user is not in the allowed group", async () => {
+    findAllByUserId.mockReturnValueOnce(
+      TE.right([] as ReadonlyArray<RetrievedUserRCConfiguration>)
+    );
+    findAllByConfigurationId.mockReturnValueOnce(
+      TE.right([] as ReadonlyArray<RetrievedRCConfiguration>)
+    );
+    const r = await listRCConfigurationHandler({
+      rcConfigurationModel: rccModelMock,
+      userRCConfigurationModel: userRCCModelMock
+    })({
+      subscriptionId: aManageSubscriptionId,
+      userGroups: someUserGroups,
+      userId: aRemoteContentConfiguration.userId
     });
     expect(r.kind).toBe("IResponseErrorForbiddenNotAuthorized");
   });

--- a/ListRCConfiguration/handler.ts
+++ b/ListRCConfiguration/handler.ts
@@ -110,12 +110,12 @@ export const listRCConfigurationExpressHandler: ListRCConfigurationHandler = ({
 
   const middlewaresWrap = withRequestMiddlewares(
     ContextMiddleware(),
-    RequiredUserIdMiddleware(),
-    RequiredSubscriptionIdMiddleware()
+    RequiredSubscriptionIdMiddleware(),
+    RequiredUserIdMiddleware()
   );
 
   return wrapRequestHandler(
-    middlewaresWrap((_, userId, subscriptionId) =>
+    middlewaresWrap((_, subscriptionId, userId) =>
       handler({ subscriptionId, userId })
     )
   );

--- a/UpdateRCConfiguration/__tests__/updateRCConfiguration.test.ts
+++ b/UpdateRCConfiguration/__tests__/updateRCConfiguration.test.ts
@@ -7,7 +7,7 @@ import { envConfig } from "../../__mocks__/env-config.mock";
 
 import {
   handleEmptyConfiguration,
-  handleGetLastRCConfigurationVersion,
+  handleGetRCConfiguration,
   handleUpsert,
   isUserAllowedToUpdateConfiguration
 } from "../handler";
@@ -67,11 +67,11 @@ describe("handleEmptyConfiguration", () => {
   });
 });
 
-describe("handleGetLastRCConfigurationVersion", () => {
+describe("handleGetRCConfiguration", () => {
   test("should return a left if the find return an error", async () => {
     findByConfigurationIdMock.mockReturnValueOnce(TE.left({}));
     const rccModel = rccModelMock;
-    const r = await handleGetLastRCConfigurationVersion(
+    const r = await handleGetRCConfiguration(
       rccModel,
       aRemoteContentConfiguration.configurationId
     )();
@@ -88,7 +88,7 @@ describe("handleGetLastRCConfigurationVersion", () => {
     findByConfigurationIdMock.mockReturnValueOnce(
       TE.right(O.some(aRemoteContentConfiguration))
     );
-    const r = await handleGetLastRCConfigurationVersion(
+    const r = await handleGetRCConfiguration(
       rccModelMock,
       aRemoteContentConfiguration.configurationId
     )();

--- a/__integrations__/__tests__/createRCConfiguration.test.ts
+++ b/__integrations__/__tests__/createRCConfiguration.test.ts
@@ -87,7 +87,12 @@ const postCreateRCConfiguration = (nodeFetch: typeof fetch) => async (
     "Content-Type": "application/json"
   };
   const headers = userId
-    ? { ...baseHeaders, "x-user-id": userId }
+    ? {
+        ...baseHeaders,
+        "x-user-id": userId,
+        "x-user-groups": "ApiRemoteContentConfigurationWrite",
+        "x-subscription-id": "MANAGE-aSubscriptionId"
+      }
     : baseHeaders;
   return await nodeFetch(`${baseUrl}/api/v1/remote-contents/configurations`, {
     method: "POST",

--- a/__integrations__/__tests__/getRCConfiguration.test.ts
+++ b/__integrations__/__tests__/getRCConfiguration.test.ts
@@ -130,7 +130,12 @@ const getRCConfiguration = (nodeFetch: typeof fetch) => async (
     "Content-Type": "application/json"
   };
   const headers = userId
-    ? { ...baseHeaders, "x-user-id": userId }
+    ? {
+        ...baseHeaders,
+        "x-user-id": userId,
+        "x-user-groups": "ApiRemoteContentConfigurationWrite",
+        "x-subscription-id": "MANAGE-aSubscriptionId"
+      }
     : baseHeaders;
   return await nodeFetch(
     `${baseUrl}/api/v1/remote-contents/configurations/${configurationId}`,

--- a/__integrations__/__tests__/listRCConfiguration.test.ts
+++ b/__integrations__/__tests__/listRCConfiguration.test.ts
@@ -19,12 +19,15 @@ import {
   anotherPublicRemoteContentConfiguration,
   anotherRemoteContentConfiguration
 } from "../__mocks__/mock.remote_content";
-import { UserRCConfiguration }from "@pagopa/io-functions-commons/dist/src/models/user_rc_configuration";
+import { UserRCConfiguration } from "@pagopa/io-functions-commons/dist/src/models/user_rc_configuration";
 import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 
 const baseUrl = "http://function:7071";
 
-export const aRemoteContentConfigurationList = [aRemoteContentConfiguration, anotherRemoteContentConfiguration];
+export const aRemoteContentConfigurationList = [
+  aRemoteContentConfiguration,
+  anotherRemoteContentConfiguration
+];
 
 const cosmosClient = new CosmosClient({
   endpoint: REMOTE_CONTENT_COSMOSDB_URI,
@@ -44,8 +47,11 @@ beforeAll(async () => {
   )();
   await fillRCConfiguration(database, aRemoteContentConfigurationList);
   const userRCConfigurations = aRemoteContentConfigurationList.map(config => {
-    return {userId: config.userId, id: config.configurationId as unknown as NonEmptyString } as UserRCConfiguration
-  }) as ReadonlyArray<UserRCConfiguration>
+    return {
+      userId: config.userId,
+      id: (config.configurationId as unknown) as NonEmptyString
+    } as UserRCConfiguration;
+  }) as ReadonlyArray<UserRCConfiguration>;
   await fillUserRCConfiguration(database, userRCConfigurations);
 });
 
@@ -84,8 +90,8 @@ describe("ListRCConfiguration", () => {
     expect(r.status).toBe(200);
     expect(response).toMatchObject({
       rcConfigList: [
-        {...anotherPublicRemoteContentConfiguration, user_id: "aUserId"},
-        {...aPublicRemoteContentConfiguration, user_id: "aUserId"}
+        { ...anotherPublicRemoteContentConfiguration, user_id: "aUserId" },
+        { ...aPublicRemoteContentConfiguration, user_id: "aUserId" }
       ]
     });
   });
@@ -98,14 +104,14 @@ const listRCConfiguration = (nodeFetch: typeof fetch) => async (
     "Content-Type": "application/json"
   };
   const headers = userId
-    ? { ...baseHeaders, "x-user-id": userId }
+    ? {
+        ...baseHeaders,
+        "x-user-id": userId,
+        "x-subscription-id": "MANAGE-aSubscriptionId"
+      }
     : baseHeaders;
-  return await nodeFetch(
-    `${baseUrl}/api/v1/remote-contents/configurations`,
-    {
-      method: "GET",
-      headers
-    }
-  );
+  return await nodeFetch(`${baseUrl}/api/v1/remote-contents/configurations`, {
+    method: "GET",
+    headers
+  });
 };
-

--- a/__integrations__/__tests__/listRCConfiguration.test.ts
+++ b/__integrations__/__tests__/listRCConfiguration.test.ts
@@ -107,6 +107,7 @@ const listRCConfiguration = (nodeFetch: typeof fetch) => async (
     ? {
         ...baseHeaders,
         "x-user-id": userId,
+        "x-user-groups": "ApiRemoteContentConfigurationWrite",
         "x-subscription-id": "MANAGE-aSubscriptionId"
       }
     : baseHeaders;

--- a/__integrations__/__tests__/updateRCConfiguration.test.ts
+++ b/__integrations__/__tests__/updateRCConfiguration.test.ts
@@ -138,7 +138,12 @@ const putCreateRCConfiguration = (nodeFetch: typeof fetch) => async (
     "Content-Type": "application/json"
   };
   const headers = userId
-    ? { ...baseHeaders, "x-user-id": userId }
+    ? {
+        ...baseHeaders,
+        "x-user-id": userId,
+        "x-user-groups": "ApiRemoteContentConfigurationWrite",
+        "x-subscription-id": "MANAGE-aSubscriptionId"
+      }
     : baseHeaders;
   return await nodeFetch(
     `${baseUrl}/api/v1/remote-contents/configurations/${configurationId}`,

--- a/__mocks__/remote-content.ts
+++ b/__mocks__/remote-content.ts
@@ -14,6 +14,7 @@ import { NewRCConfigurationPublic } from "../generated/definitions/NewRCConfigur
 import { FiscalCode } from "../generated/definitions/FiscalCode";
 import { aCosmosResourceMetadata } from "./models.mock";
 import { MANAGE_SUBSCRIPTION_PREFIX } from "../utils/apim";
+import { ALLOWED_RC_CONFIG_API_GROUP } from "../utils/remote_content";
 
 const aPublicDetailAuthentication = {
   header_key_name: "a" as NonEmptyString,
@@ -30,6 +31,8 @@ const aDetailAuthentication = {
 export const aUserId = "aUserId" as NonEmptyString;
 export const aSubscriptionId = "aSubscriptionId" as NonEmptyString;
 export const aManageSubscriptionId = `${MANAGE_SUBSCRIPTION_PREFIX}${aSubscriptionId}` as NonEmptyString;
+export const someUserGroups = "GroupA,GroupB,GroupC" as NonEmptyString;
+export const someUserGroupsWithTheAllowedOne = `${someUserGroups},${ALLOWED_RC_CONFIG_API_GROUP}` as NonEmptyString;
 
 export const aRemoteContentConfiguration: RCConfiguration = {
   hasPrecondition: HasPreconditionEnum.ALWAYS,

--- a/__mocks__/remote-content.ts
+++ b/__mocks__/remote-content.ts
@@ -13,6 +13,7 @@ import {
 import { NewRCConfigurationPublic } from "../generated/definitions/NewRCConfigurationPublic";
 import { FiscalCode } from "../generated/definitions/FiscalCode";
 import { aCosmosResourceMetadata } from "./models.mock";
+import { MANAGE_SUBSCRIPTION_PREFIX } from "../utils/apim";
 
 const aPublicDetailAuthentication = {
   header_key_name: "a" as NonEmptyString,
@@ -27,6 +28,8 @@ const aDetailAuthentication = {
 };
 
 export const aUserId = "aUserId" as NonEmptyString;
+export const aSubscriptionId = "aSubscriptionId" as NonEmptyString;
+export const aManageSubscriptionId = `${MANAGE_SUBSCRIPTION_PREFIX}${aSubscriptionId}` as NonEmptyString;
 
 export const aRemoteContentConfiguration: RCConfiguration = {
   hasPrecondition: HasPreconditionEnum.ALWAYS,
@@ -61,7 +64,7 @@ export const anotherRemoteContentConfiguration: RCConfiguration = {
 export const aRetrievedRemoteContentConfiguration: RetrievedRCConfiguration = {
   ...aRemoteContentConfiguration,
   ...aCosmosResourceMetadata,
-  id: `${aRemoteContentConfiguration.configurationId}` as NonEmptyString,
+  id: `${aRemoteContentConfiguration.configurationId}` as NonEmptyString
 };
 
 export const aPublicRemoteContentConfiguration: NewRCConfigurationPublic = {

--- a/middlewares/required_headers_middleware.ts
+++ b/middlewares/required_headers_middleware.ts
@@ -37,3 +37,18 @@ export const RequiredUserIdMiddleware = (): IRequestMiddleware<
     E.mapLeft(() => ResponseErrorForbiddenAnonymousUser),
     T.of
   )();
+
+export const RequiredSubscriptionIdMiddleware = (): IRequestMiddleware<
+  "IResponseErrorForbiddenAnonymousUser",
+  NonEmptyString
+> => (
+  request
+): Promise<
+  E.Either<IResponse<"IResponseErrorForbiddenAnonymousUser">, NonEmptyString>
+> =>
+  pipe(
+    request.header("x-subscription-id"),
+    NonEmptyString.decode,
+    E.mapLeft(() => ResponseErrorForbiddenAnonymousUser),
+    T.of
+  )();

--- a/middlewares/required_headers_middleware.ts
+++ b/middlewares/required_headers_middleware.ts
@@ -3,7 +3,8 @@ import * as T from "fp-ts/lib/Task";
 import { IRequestMiddleware } from "@pagopa/ts-commons/lib/request_middleware";
 import {
   IResponse,
-  ResponseErrorForbiddenAnonymousUser
+  ResponseErrorForbiddenAnonymousUser,
+  ResponseErrorForbiddenNotAuthorized
 } from "@pagopa/ts-commons/lib/responses";
 import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 import { pipe } from "fp-ts/lib/function";
@@ -50,5 +51,20 @@ export const RequiredSubscriptionIdMiddleware = (): IRequestMiddleware<
     request.header("x-subscription-id"),
     NonEmptyString.decode,
     E.mapLeft(() => ResponseErrorForbiddenAnonymousUser),
+    T.of
+  )();
+
+export const RequiredUserGroupsMiddleware = (): IRequestMiddleware<
+  "IResponseErrorForbiddenNotAuthorized",
+  NonEmptyString
+> => (
+  request
+): Promise<
+  E.Either<IResponse<"IResponseErrorForbiddenNotAuthorized">, NonEmptyString>
+> =>
+  pipe(
+    request.header("x-user-groups"),
+    NonEmptyString.decode,
+    E.mapLeft(() => ResponseErrorForbiddenNotAuthorized),
     T.of
   )();

--- a/utils/apim.ts
+++ b/utils/apim.ts
@@ -2,5 +2,6 @@ import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 
 export const MANAGE_SUBSCRIPTION_PREFIX = "MANAGE-";
 
-export const isManageSubscription = (subscriptionId: NonEmptyString): boolean =>
-  subscriptionId.startsWith(MANAGE_SUBSCRIPTION_PREFIX);
+export const manageSubscriptionCheck = (
+  subscriptionId: NonEmptyString
+): boolean => subscriptionId.startsWith(MANAGE_SUBSCRIPTION_PREFIX);

--- a/utils/apim.ts
+++ b/utils/apim.ts
@@ -1,0 +1,6 @@
+import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
+
+export const MANAGE_SUBSCRIPTION_PREFIX = "MANAGE-";
+
+export const isManageSubscription = (subscriptionId: NonEmptyString): boolean =>
+  subscriptionId.startsWith(MANAGE_SUBSCRIPTION_PREFIX);

--- a/utils/cosmosdb.ts
+++ b/utils/cosmosdb.ts
@@ -2,7 +2,6 @@
  * Use a singleton CosmosDB client across functions.
  */
 import { CosmosClient } from "@azure/cosmos";
-
 import { getConfigOrThrow } from "../utils/config";
 
 const config = getConfigOrThrow();

--- a/utils/remote_content.ts
+++ b/utils/remote_content.ts
@@ -1,0 +1,24 @@
+import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
+import { pipe } from "fp-ts/lib/function";
+import * as TE from "fp-ts/lib/TaskEither";
+import {
+  IResponseErrorForbiddenNotAuthorized,
+  ResponseErrorForbiddenNotAuthorized
+} from "@pagopa/ts-commons/lib/responses";
+import { manageSubscriptionCheck } from "./apim";
+
+export const ALLOWED_RC_CONFIG_API_GROUP = "ApiRemoteContentConfigurationWrite";
+
+export const checkGroupAndManageSubscription = (
+  subscriptionId: NonEmptyString,
+  userGroups: NonEmptyString
+): TE.TaskEither<IResponseErrorForbiddenNotAuthorized, boolean> =>
+  pipe(
+    manageSubscriptionCheck(subscriptionId),
+    TE.fromPredicate(
+      isManageSubscription =>
+        isManageSubscription &&
+        userGroups.indexOf(ALLOWED_RC_CONFIG_API_GROUP) > -1,
+      _ => ResponseErrorForbiddenNotAuthorized
+    )
+  );

--- a/utils/response.ts
+++ b/utils/response.ts
@@ -1,0 +1,10 @@
+import { CosmosErrors } from "@pagopa/io-functions-commons/dist/src/utils/cosmosdb_model";
+import {
+  IResponseErrorInternal,
+  ResponseErrorInternal
+} from "@pagopa/ts-commons/lib/responses";
+
+export const handleCosmosErrorResponse = (message: string) => (
+  error: CosmosErrors
+): IResponseErrorInternal =>
+  ResponseErrorInternal(`${message}: ${JSON.stringify(error)}`);


### PR DESCRIPTION
#### List of Changes
Added user group check.
Added manage subscription check.
Fixed tests.

#### Motivation and Context
We need to check that the subscription is a manage one.

#### How Has This Been Tested?
unit tests
integration tests

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)